### PR TITLE
Implement DenseMatrix transpose view for efficient memory sharing

### DIFF
--- a/include/concept/matrix.cuh
+++ b/include/concept/matrix.cuh
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <type_traits>
 #include <span>
+#include <utility>
 
 namespace xyz_autodiff {
 


### PR DESCRIPTION
## Summary

- Add DenseMatrixTransposeView class that holds reference to original matrix
- Transpose view swaps row/col dimensions and provides transposed coordinate mapping
- Implements Variable and MatrixView concepts with shared data/gradient arrays
- Replace transpose() method to return view instead of copying data
- Fix missing include utility in matrix.cuh for std::as_const

Resolves issue #6

Generated with [Claude Code](https://claude.ai/code)